### PR TITLE
Small improvements for the command line interface

### DIFF
--- a/vocexcel/convert.py
+++ b/vocexcel/convert.py
@@ -534,6 +534,11 @@ def main(args=None):
 
     args = parser.parse_args()
 
+    if len(sys.argv)==1:
+        # show help if no args are given
+        parser.print_help()
+        parser.exit()
+
     if args.listprofiles:
         s = "Profiles\nToken\tIRI\n-----\t-----\n"
         for k, v in profiles.PROFILES.items():

--- a/vocexcel/convert_043.py
+++ b/vocexcel/convert_043.py
@@ -1,3 +1,5 @@
+import logging
+
 from typing import Tuple, List
 
 from openpyxl.worksheet.worksheet import Worksheet
@@ -134,7 +136,7 @@ def using_prefix_and_namespace(cell_value, prefix, s: Worksheet, row):
                     raise Exception
                 variables.append(c)
             except Exception as e:
-                print(e)
+                logging.exception(e)
     return variables
 
 


### PR DESCRIPTION
- Make excel/rdf-file an optional arg
- Remove/replace use of exit() which is not a buildin.
- Show help message if vocexcel is run without args
- Change the excel file extension check to be case-insensitive.
