### PR TITLE
Fix use of args argument in main.

### DIFF
--- a/vocexcel/convert.py
+++ b/vocexcel/convert.py
@@ -436,7 +436,14 @@ def log_msg(result: Dict, log_file: str) -> str:
 
 
 def main(args=None):
+
+    if args is None:  # vocexcel run via entrypoint
+        args = sys.argv[1:]
+
+    has_args = True if args else False
+
     parser = argparse.ArgumentParser(
+        prog="vocexcel",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
@@ -530,9 +537,9 @@ def main(args=None):
         "-l", "--logfile", help="The file to write logging output to", required=False
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
-    if len(sys.argv) == 1:
+    if not has_args:
         # show help if no args are given
         parser.print_help()
         parser.exit()


### PR DESCRIPTION
`args` are now passed further down to `parse_args()` so that it does not fall back to using `sys.argv`.

Closes #32