### PR TITLE
New option to use custom Excel-template

### DIFF
--- a/vocexcel/utils.py
+++ b/vocexcel/utils.py
@@ -15,6 +15,7 @@ RDF_FILE_ENDINGS = {
 }
 KNOWN_FILE_ENDINGS = [str(x) for x in RDF_FILE_ENDINGS.keys()] + EXCEL_FILE_ENDINGS
 KNOWN_TEMPLATE_VERSIONS = ["0.2.1", "0.3.0", "0.4.0", "0.4.1", "0.4.2", "0.4.3"]
+LATEST_TEMPLATE = KNOWN_TEMPLATE_VERSIONS[-1]
 
 
 class ConversionError(Exception):
@@ -22,8 +23,20 @@ class ConversionError(Exception):
 
 
 def load_workbook(file_path: Path) -> Workbook:
-    if not file_path.name.endswith(tuple(EXCEL_FILE_ENDINGS)):
+    if not file_path.name.lower().endswith(tuple(EXCEL_FILE_ENDINGS)):
         raise ValueError("Files for conversion to RDF must be Excel files ending .xlsx")
+    return _load_workbook(filename=str(file_path), data_only=True)
+
+
+def load_template(file_path: Path) -> Workbook:
+    if not file_path.name.lower().endswith(tuple(EXCEL_FILE_ENDINGS)):
+        raise ValueError(
+            "Template files for RDF-to-Excel conversion must be Excel files ending .xlsx"
+        )
+    if get_template_version(load_workbook(file_path)) != LATEST_TEMPLATE:
+        raise ValueError(
+            f"Template files for RDF-to-Excel conversion must be of latest version ({LATEST_TEMPLATE})"
+        )
     return _load_workbook(filename=str(file_path), data_only=True)
 
 


### PR DESCRIPTION
Since SKOS-to-Excel is now working again (#30) it would be nice to support using customized "branded" excel templates. With this it is possible to convert excel -> rdf -> excel without loosing the template customization.

This PR adds a new option:
```
-t TEMPLATEFILE, --templatefile TEMPLATEFILE
                        An optionally-provided Excel-template file to be used in SKOS-> Excel
                        converion. (default: None)
```
