### PR TITLE
Make .pre-commit windows compatible & update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.2.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 22.3.0
     hooks:
     -   id: black
-        entry: bash -c 'black . && git add -u' --
+        entry: black
 - repo: local
   hooks:
   - id: update-requirements-txt


### PR DESCRIPTION
Since bash is used the current .pe-commit config does not work on windows. This fixes it and updates the hooks. You loose the convenience of running black and git add in one step.